### PR TITLE
travis: before_cache rm path was fixed to 4.4 gradle.README: Kotlin and Gradle banges was fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ sudo: false
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-  - rm -f  $HOME/.gradle/caches/3.4.1/fileHashes/fileHashes.bin
-  - rm -f  $HOME/.gradle/caches/3.4.1/fileHashes/fileHashes.lock
+  - rm -f  $HOME/.gradle/caches/4.4/fileHashes/fileHashes.bin
+  - rm -f  $HOME/.gradle/caches/4.4/fileHashes/fileHashes.lock
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](https://img.shields.io/badge/Java-1.8-orange.svg)
-![](https://img.shields.io/badge/Kotlin-1.1.2-blue.svg)
-![](https://img.shields.io/badge/Gradle-3.4-brightgreen.svg)
+![](https://img.shields.io/badge/Kotlin-1.2.10-blue.svg)
+![](https://img.shields.io/badge/Gradle-4.4-brightgreen.svg)
 ![](https://img.shields.io/badge/waifu-inside-blue.svg)
 [![Build Status](https://travis-ci.org/DeskChan/DeskChan.svg?branch=master)](https://travis-ci.org/DeskChan/DeskChan)
 


### PR DESCRIPTION
travis: before_cache rm path was fixed to 4.4 gradle.
README: Kotlin and Gradle banges was fixed