### PR TITLE
Add core plugin tests

### DIFF
--- a/src/main/java/info/deskchan/core/CorePlugin.java
+++ b/src/main/java/info/deskchan/core/CorePlugin.java
@@ -5,8 +5,8 @@ import java.util.*;
 
 public class CorePlugin implements Plugin, MessageListener {
 	
-	private PluginProxyInterface pluginProxy = null;
-	private final Map<String, List<AlternativeInfo>> alternatives = new HashMap<>();
+	protected PluginProxyInterface pluginProxy = null;
+	protected final Map<String, List<AlternativeInfo>> alternatives = new HashMap<>();
 
 	@Override
 	public boolean initialize(PluginProxyInterface pluginProxy) {
@@ -126,7 +126,6 @@ public class CorePlugin implements Plugin, MessageListener {
 		});
 
 		CommandsProxy.initialize(pluginProxy);
-		// Testing();
 
 		return true;
 	}
@@ -236,7 +235,7 @@ public class CorePlugin implements Plugin, MessageListener {
 		} catch (NoSuchElementException e) { }
 	}
 	
-	private static class AlternativeInfo {
+	static class AlternativeInfo {
 		String tag;
 		String plugin;
 		int priority;
@@ -255,61 +254,5 @@ public class CorePlugin implements Plugin, MessageListener {
 		public String toString(){
 			return tag + "(" + plugin + ")" + "=" + priority;
 		}
-	}
-
-	/** Testing alternatives. Very good example of using. **/
-	void Testing(){
-		pluginProxy.addMessageListener("core:test1", (sender, tag, data) -> {
-			System.out.println("test 1");
-			pluginProxy.sendMessage("DeskChan:test#core:test1", null);
-		});
-
-		pluginProxy.addMessageListener("core:test2", (sender, tag, data) -> {
-			System.out.println("test 2");
-			pluginProxy.sendMessage("DeskChan:test#core:test2", null);
-		});
-
-		pluginProxy.addMessageListener("core:test3", (sender, tag, data) -> {
-			System.out.println("test 3");
-		});
-
-		pluginProxy.sendMessage("core:register-alternative", new HashMap<String, Object>(){{
-			put("srcTag", "DeskChan:test");
-			put("dstTag", "core:test1");
-			put("priority", 1000);
-		}});
-
-		pluginProxy.sendMessage("core:register-alternative", new HashMap<String, Object>(){{
-			put("srcTag", "DeskChan:test");
-			put("dstTag", "core:test2");
-			put("priority", 500);
-		}});
-
-		System.out.println(alternatives);
-		pluginProxy.sendMessage("DeskChan:test", null);
-
-		pluginProxy.sendMessage("core:unregister-alternative", new HashMap<String, Object>(){{
-			put("srcTag", "DeskChan:test");
-			put("dstTag", "core:test1");
-		}});
-
-		pluginProxy.sendMessage("core:register-alternative", new HashMap<String, Object>(){{
-			put("srcTag", "DeskChan:test");
-			put("dstTag", "core:test3");
-			put("priority", 1500);
-		}});
-
-		System.out.println(alternatives);
-		pluginProxy.sendMessage("DeskChan:test", null);
-
-		pluginProxy.sendMessage("core:register-alternative", new HashMap<String, Object>(){{
-			put("srcTag", "DeskChan:test");
-			put("dstTag", "core:test3");
-			put("priority", 400);
-		}});
-
-		System.out.println(alternatives);
-		pluginProxy.sendMessage("DeskChan:test", null);
-
 	}
 }

--- a/src/main/java/info/deskchan/core/CorePlugin.java
+++ b/src/main/java/info/deskchan/core/CorePlugin.java
@@ -31,7 +31,11 @@ public class CorePlugin implements Plugin, MessageListener {
 			if(delay > 20)
 				pluginProxy.sendMessage("core-utils:notify-after-delay", m, (s, d) -> PluginManager.getInstance().quit() );
 			else
+			{
 				PluginManager.getInstance().quit();
+				System.exit(0);
+			}
+
 		});
 
 		/* Registers alternative to tag. All messages sent to srcTag will be redirected to dstTag

--- a/src/main/java/info/deskchan/core/PluginManager.java
+++ b/src/main/java/info/deskchan/core/PluginManager.java
@@ -583,7 +583,7 @@ public class PluginManager {
 		if (debugBuild) {
 			path = corePath;
 			try {
-				while (!path.endsWith("build"))
+                while (!IsPathEndsWithList(path,debugBuildFolders))
 					path = path.getParent();
 				path = path.getParent();
 			} catch (Exception e){

--- a/src/main/java/info/deskchan/core/PluginManager.java
+++ b/src/main/java/info/deskchan/core/PluginManager.java
@@ -426,7 +426,6 @@ public class PluginManager {
 			}
 			logStream = null;
 		}
-		System.exit(0);
 	}
 
 	/** Get list of plugins. **/

--- a/src/main/java/info/deskchan/core/PluginManager.java
+++ b/src/main/java/info/deskchan/core/PluginManager.java
@@ -22,6 +22,7 @@ public class PluginManager {
 	private static OutputStream logStream = null;
 
 	private static boolean debugBuild = false;
+    private static String[] debugBuildFolders = { "build", "out" };
 
 	Set<MessageListener> getMessageListeners(String key){
 		int delimiterPas = key.indexOf('#');
@@ -265,6 +266,15 @@ public class PluginManager {
 			return false;
 		}
 	}
+
+    private static boolean IsPathEndsWithList(Path path,String[] names){
+	    for(String name: names){
+	        if (path.endsWith(name))
+	            return true;
+        }
+
+                return false;
+    }
 
 	/** Load plugin by its class name.
 	 * @param className Class name

--- a/src/main/java/info/deskchan/core/PluginManager.java
+++ b/src/main/java/info/deskchan/core/PluginManager.java
@@ -77,6 +77,10 @@ public class PluginManager {
 		return plugins.keySet();
 	}
 
+	PluginProxy getPlugin(String name){
+		return plugins.get(name);
+	}
+
 	/* Plugin initialization and unloading */
 
 	/** Plugin initialization. Use other methods of this class if you haven't all needed components

--- a/src/test/java/info/deskchan/core/CorePluginTests.java
+++ b/src/test/java/info/deskchan/core/CorePluginTests.java
@@ -1,0 +1,134 @@
+package info.deskchan.core;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class CorePluginTests {
+    private static PluginManager pluginManager;
+
+    private Map<String, List<CorePlugin.AlternativeInfo>> alternatives = null;
+    private static PluginProxy pluginProxy = null;
+
+    private void getAlternatives(){
+        alternatives = null;
+        pluginProxy.sendMessage("core:debug-output-alternatives", null, (sender, data) -> {
+            alternatives = (Map<String, List<CorePlugin.AlternativeInfo>>) data;
+            System.out.println("++++++++++++++");
+            System.out.println(alternatives);
+            System.out.println("++++++++++++++");
+        });
+        Assert.assertNotNull(alternatives);
+    }
+
+    @BeforeClass
+    public static void before() {
+        pluginManager = PluginManager.getInstance();
+        String[] args = {};
+        pluginManager.initialize(args);
+        pluginManager.unloadPlugin("core");
+        System.out.println("original core was unload");
+        pluginManager.tryLoadPluginByClass(ProxyCore.class);
+        System.out.println("ProxyCore was load");
+        pluginProxy = pluginManager.getPlugin("core");
+    }
+
+    @AfterClass
+    public static void after() {
+        pluginManager.quit();
+    }
+
+    @Test
+    public void test0() throws InterruptedException {
+
+        pluginProxy.addMessageListener("core:test1", (sender, tag, data) -> {
+            System.out.println("test 1");
+            pluginProxy.sendMessage("DeskChan:test#core:test1", null);
+        });
+
+        pluginProxy.addMessageListener("core:test2", (sender, tag, data) -> {
+            System.out.println("test 2");
+            pluginProxy.sendMessage("DeskChan:test#core:test2", null);
+        });
+
+        pluginProxy.addMessageListener("core:test3", (sender, tag, data) -> {
+            System.out.println("test 3");
+        });
+
+        System.out.println("sendMessage->core:register-alternative@(srcTag:DeskChan:test->dstTag:core:test1,priority:1000)");
+        pluginProxy.sendMessage("core:register-alternative", new HashMap<String, Object>() {{
+            put("srcTag", "DeskChan:test");
+            put("dstTag", "core:test1");
+            put("priority", 1000);
+        }});
+
+        System.out.println("sendMessage->core:register-alternative");
+        pluginProxy.sendMessage("core:register-alternative", new HashMap<String, Object>() {{
+            put("srcTag", "DeskChan:test");
+            put("dstTag", "core:test2");
+            put("priority", 500);
+        }});
+
+        getAlternatives();
+
+
+        List<CorePlugin.AlternativeInfo> list = alternatives.get("DeskChan:test");
+        Assert.assertEquals(list.get(0).tag, "core:test1");
+        Assert.assertEquals(list.get(0).plugin,"core");
+        Assert.assertEquals(list.get(0).priority,1000);
+
+        CorePlugin.AlternativeInfo alternativeInfo2 = list.get(1);
+        Assert.assertEquals(list.get(1).tag, "core:test2");
+        Assert.assertEquals(list.get(1).plugin,"core");
+        Assert.assertEquals(list.get(1).priority,500);
+
+        pluginProxy.sendMessage("DeskChan:test", null);
+
+        pluginProxy.sendMessage("core:unregister-alternative", new HashMap<String, Object>(){{
+            put("srcTag", "DeskChan:test");
+            put("dstTag", "core:test1");
+        }});
+
+        getAlternatives();
+        Assert.assertEquals(list.get(0).tag, "core:test2");
+        Assert.assertEquals(list.get(0).plugin, "core");
+        Assert.assertEquals(list.get(0).priority, 500);
+
+        pluginProxy.sendMessage("core:register-alternative", new HashMap<String, Object>(){{
+            put("srcTag", "DeskChan:test");
+            put("dstTag", "core:test3");
+            put("priority", 1500);
+        }});
+
+        getAlternatives();
+        Assert.assertEquals(list.get(0).tag, "core:test3");
+        Assert.assertEquals(list.get(0).plugin, "core");
+        Assert.assertEquals(list.get(0).priority, 1500);
+
+        pluginProxy.sendMessage("DeskChan:test", null);
+
+        pluginProxy.sendMessage("core:register-alternative", new HashMap<String, Object>(){{
+            put("srcTag", "DeskChan:test");
+            put("dstTag", "core:test3");
+            put("priority", 400);
+        }});
+        getAlternatives();
+        Assert.assertEquals(list.get(0).tag, "core:test2");
+        Assert.assertEquals(list.get(0).plugin, "core");
+        Assert.assertEquals(list.get(0).priority, 500);
+
+        Assert.assertEquals(list.get(1).tag, "core:test3");
+        Assert.assertEquals(list.get(1).plugin, "core");
+        Assert.assertEquals(list.get(1).priority, 400);
+        
+        pluginProxy.sendMessage("DeskChan:test", null);
+    }
+}
+
+

--- a/src/test/java/info/deskchan/core/PluginManagerTests.java
+++ b/src/test/java/info/deskchan/core/PluginManagerTests.java
@@ -1,0 +1,25 @@
+package info.deskchan.core;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class PluginManagerTests {
+    static PluginManager pluginManager;
+    @BeforeClass
+    public static void before() {
+        pluginManager = PluginManager.getInstance();
+        String[] args = {};
+        pluginManager.initialize(args);
+    }
+
+    @Test
+    public void test0() {
+        System.out.println("Plugins list");
+        List<String> plugins = pluginManager.getPlugins();
+        for (String plugin : plugins) {
+            System.out.println(plugin);
+        }
+    }
+}

--- a/src/test/java/info/deskchan/core/ProxyCore.java
+++ b/src/test/java/info/deskchan/core/ProxyCore.java
@@ -1,0 +1,19 @@
+package info.deskchan.core;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ProxyCore extends CorePlugin implements Plugin, MessageListener {
+
+    @Override
+    public boolean initialize(PluginProxyInterface pluginProxy) {
+        boolean initializeStatus = super.initialize(pluginProxy);
+
+        pluginProxy.addMessageListener("core:debug-output-alternatives", (sender, tag, data) -> {
+            pluginProxy.sendMessage(sender, new HashMap<String, List<AlternativeInfo>>(alternatives));
+        });
+
+        return initializeStatus;
+    }
+}


### PR DESCRIPTION
tests: PluginManagerTests was added.(first PluginManagerTests test) 
PluginManager: the problem of running the PluginManager tests from IDEA was fixed.(Build path in idea is DeskChan\out,gradle - DeskChan\build.)

CorePlugin: pluginProxy and alternatives scope was changed to protected,AlternativeInfo scope was changed to default (package-private),Testing() method was removed
test/ProxyCore: core:debug-output-alternatives command was was added.
PluginManager: getPlugin method was added(default (package-private))
PluginManager && CorePlugin: System.exit was moved from PluginManager in CorePlugin